### PR TITLE
Add warning to rack-timeout - it makes your process unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,8 @@ Raises `Rack::Timeout::RequestTimeoutError` or `Rack::Timeout::RequestExpiryErro
 
 [Read more here](https://github.com/heroku/rack-timeout#the-rabbit-hole)
 
+**Caveat:** `rack-timeout` is fundamentally unsafe as described [previously](#the-ultimate-guide-to-ruby-timeouts).
+
 ### slowpoke
 
 ```ruby


### PR DESCRIPTION
As it raises exceptions across threads, the entire point of this list of settings is to avoid that unfortunate behaviour :steam_locomotive: 
