### PR TITLE
rest-client 2.0 updated interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,10 @@ Raises
 - `Net::OpenTimeout` on connect timeout
 - `Net::ReadTimeout` on read timeout
 
+Defaults: 60s read timeout.  Connect timeout was infinite till Ruby 2.2, [became 60s in Ruby 2.3](https://github.com/ruby/ruby/commit/52e1c3b0ab41041f7f51a7afc3fce3aab97bc010).
+
+Write timeout is infinite, presently [can't be set](https://bugs.ruby-lang.org/issues/13396).
+
 **Note:** Read timeouts are [retried automatically](https://github.com/ruby/ruby/blob/v2_2_4/lib/net/http.rb#L1436)
 
 ### open-uri

--- a/README.md
+++ b/README.md
@@ -513,10 +513,20 @@ Raises `Patron::TimeoutError`
 ### rest-client
 
 ```ruby
-RestClient::Request.execute(method: :get, url: url, open_timeout: 1, timeout: 1)
+RestClient::Request.execute(method: :get, url: url, open_timeout: 1, read_timeout: 1)
+
+# shorthand to set open_timeout = read_timeout = 1
+RestClient::Request.execute(method: :get, url: url, timeout: 1)
 ```
 
-Raises `RestClient::RequestTimeout`
+Same options also work with `RestClient::Resource`.
+
+Raises:
+
+- `RestClient::Exceptions::OpenTimeout` on connect timeout
+- `RestClient::Exceptions::ReadTimeout` on read timeout
+
+Defaults: inherited from net/http — 60s both since Ruby 2.3.
 
 ### typhoeus
 
@@ -820,6 +830,8 @@ Use
 - `HTTPClient::TimeoutError` for both `HTTPClient::ConnectTimeoutError` and `HTTPClient::ReceiveTimeoutError`
 - `Redis::BaseConnectionError` for both `Redis::CannotConnectError` and `Redis::TimeoutError`
 - `Rack::Timeout::Error` for both `Rack::Timeout::RequestTimeoutError` and `Rack::Timeout::RequestExpiryError`
+- `RestClient::Exceptions::Timeout` for both `RestClient::Exceptions::OpenTimeout` and `RestClient::Exceptions::ReadTimeout`
+
 
 ## Existing Services
 


### PR DESCRIPTION
https://github.com/rest-client/rest-client/blob/master/history.md#200

omitted details for guide brevity:

- rest-client is based on net/http so read timeouts are retried automatically (#8).

- Before 2.0 `read_timeout` was named `timeout`, and all timeouts raised `RestClient::RequestTimeout`, which was ambiguous with successful HTTP 408 status.

- reading `.read_timeout`, `.open_timeout` back presently doesn't always return actual value (https://github.com/rest-client/rest-client/issues/591), fixing.

also added some net/http details/links