### PR TITLE
Instructions for per-process statement timeouts in Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,18 @@ SET LOCAL statement_timeout = 250;
 COMMIT;
 ```
 
+You may want to be able to customize `statement_timeout` per process. For example, to increase the timeout in database migrations, allow overriding the default with an envrionment variable.
+
+```yml
+production:
+  variables:
+    statement_timeout: <%= ENV['PG_STATEMENT_TIMEOUT'] || 250 %>
+```
+
+```bash
+PG_STATEMENT_TIMEOUT=90s rails db:migrate
+```
+
 ### MySQL
 
 **Note:** Requires MySQL 5.7.8 or higher


### PR DESCRIPTION
After setting `statement_timeout` in `database.yml` of my Rails app, I ran into an issue where statements in migrations would time out. I think its pretty common to have long-running operations in migrations relative to what a typical `statement_timeout` in your application would be. Thought I'd suggest adding how to do this in Rails.