### PR TITLE
new default for redis gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ Raises
 Redis.new(connect_timeout: 1, timeout: 1, ...)
 ```
 
-Default: 5s
+Default: 1s after 5.0, 5s before
 
 Raises
 


### PR DESCRIPTION
https://rubygems.org/gems/redis/versions/5.0.0

https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#500