### PR TITLE
Downcase Meilisearch top level module

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,10 +608,10 @@ Raises `InfluxDB2::InfluxError`
 ### meilisearch
 
 ```ruby
-MeiliSearch::Client.new(url, api_key, timeout: 1)
+Meilisearch::Client.new(url, api_key, timeout: 1)
 ```
 
-Raises `MeiliSearch::TimeoutError`
+Raises `Meilisearch::TimeoutError`
 
 ### mongo
 


### PR DESCRIPTION
Community maintainer of Meilisearch's gems here :wave: 

We recently downcased the top-level module: https://github.com/meilisearch/meilisearch-ruby/releases/tag/v0.30.0

Ran across this repository for something unrelated and noticed.

P. S.: The old code sample should still work but it will print a warning, since it's only soft deprecated for now.